### PR TITLE
Server interface improvements and redesign of message handling logic

### DIFF
--- a/.github/workflows/linux-setup.yaml
+++ b/.github/workflows/linux-setup.yaml
@@ -1,5 +1,5 @@
 name: linux-setup
-run-name: linux-setup ${{ github.actor }}-{{ github.event.pull_request.number }}-${{ github.run_number }} 😸
+run-name: linux-setup ${{ github.actor }}-${{ github.event.pull_request.number }}-${{ github.run_number }} 😸
 
 on:
   workflow_call:

--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -1,5 +1,5 @@
 name: linux
-run-name: linux ${{ github.actor }}-{{ github.event.pull_request.number }}-${{ github.run_number }} 😸
+run-name: linux ${{ github.actor }}-${{ github.event.pull_request.number }}-${{ github.run_number }} 😸
 
 on:
   workflow_dispatch:

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -1,5 +1,5 @@
 name: unit-tests
-run-name: unit-tests ${{ github.actor }}-{{ github.event.pull_request.number }}-${{ github.run_number }} 😸
+run-name: unit-tests ${{ github.actor }}-${{ github.event.pull_request.number }}-${{ github.run_number }} 😸
 
 on:
   workflow_call:

--- a/.github/workflows/windows-setup.yaml
+++ b/.github/workflows/windows-setup.yaml
@@ -1,5 +1,5 @@
 name: windows-setup
-run-name: windows-setup ${{ github.actor }}-{{ github.event.pull_request.number }}-${{ github.run_number }} 😸
+run-name: windows-setup ${{ github.actor }}-${{ github.event.pull_request.number }}-${{ github.run_number }} 😸
 
 
 on:

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -1,5 +1,5 @@
 name: windows
-run-name: windows ${{ github.actor }}-{{ github.event.pull_request.number }}-${{ github.run_number }} 😸
+run-name: windows ${{ github.actor }}-${{ github.event.pull_request.number }}-${{ github.run_number }} 😸
 
 on:
   workflow_dispatch:

--- a/examples/chat/include/client/client.h
+++ b/examples/chat/include/client/client.h
@@ -17,7 +17,6 @@ class client : public wired::client_interface<message_types> {
     void on_message(message_t& msg, connection_ptr conn) override;
 
   public:
-    std::thread update_thread;
     std::string name;
     uint32_t id;
 };

--- a/examples/chat/src/client/main.cpp
+++ b/examples/chat/src/client/main.cpp
@@ -12,18 +12,15 @@ int main() {
 
     auto future = chatter.connect(SERVER_ADDR, SERVER_PORT);
     bool connected = future.get();
+
     assert(connected);
-    assert(chatter.is_connected());
+
     std::cout << std::format("{}, you have connected to the server\n",
                              chatter.name);
 
-    chatter.update_thread = std::thread([&]() {
-        while (chatter.is_connected()) {
-            chatter.update();
-        }
-    });
-    chatter.update_thread.detach();
     std::cout << "You can start chatting now. Type 'exit' to quit.\n";
+
+    chatter.run(wired::execution_policy::non_blocking);
 
     while (chatter.is_connected()) {
         std::string message;
@@ -34,6 +31,7 @@ int main() {
         if (message.empty()) {
             continue;
         }
+        std::cout << "DEBUG: Sending message: " << message << std::endl;
         wired::message<message_types> msg(message_types::client_message);
         msg << chatter.name;
         msg << message;

--- a/examples/chat/src/server/main.cpp
+++ b/examples/chat/src/server/main.cpp
@@ -10,11 +10,9 @@ int main() {
     std::cout << "Server started on port " << SERVER_PORT << std::endl;
     std::cout << "Press Ctrl+C to stop the server." << std::endl;
 
-    while (true) {
-        serv.update();
-    }
+    serv.run(wired::execution_policy::blocking);
 
-    serv.stop();
+    serv.shutdown();
 
     return 0;
 }

--- a/examples/simple_application/src/client.cpp
+++ b/examples/simple_application/src/client.cpp
@@ -2,23 +2,33 @@
 #include "wired.h"
 
 #include <iostream>
+#include <format>
 
-struct client : wired::client_interface<common_messages> {
-    client() : wired::client_interface<common_messages>() {}
+constexpr uint32_t num_of_pings = 3;
+
+using namespace wired;
+
+struct client : client_interface<common_messages> {
+    client() : client_interface<common_messages>() {}
     void on_message(message_t& msg, connection_ptr conn) override {
-        if (times_pinged >= 3) {
-            std::cout << "[client]: stopping\n";
-            disconnect();
-            std::cout << "[client]: stopped\n";
-        }
         std::cout << "[client]: update\n";
         switch (msg.id()) {
         case common_messages::server_ping: {
-            std::cout << "[client]: I got a ping from the server!\n";
-            sleep(1);
-            wired::message<common_messages> msg(common_messages::client_ping);
-            send(msg);
             ++times_pinged;
+            std::cout << std::format(
+                "[client]: I got a ping from the server! === {}/{}\n",
+                times_pinged, num_of_pings);
+
+            if (times_pinged >= num_of_pings) {
+                std::cout << "[client]: stopping\n";
+                auto future = disconnect();
+                future.wait();
+                std::cout << "[client]: stopped\n";
+                return;
+            }
+            message<common_messages> msg(common_messages::client_ping);
+            send(msg);
+
             break;
         }
         default: {
@@ -32,7 +42,7 @@ struct client : wired::client_interface<common_messages> {
 };
 
 int main() {
-    WIRED_LOG_LEVEL(wired::log_level::LOG_DEBUG);
+    WIRED_LOG_LEVEL(log_level::LOG_DEBUG);
     client simple_client;
     std::cout << "[client]: starting\n";
     std::future<bool> connect_result =
@@ -42,16 +52,15 @@ int main() {
     assert(simple_client.is_connected());
     std::cout << "[client]: connected\n";
 
-    wired::message<common_messages> msg(common_messages::client_ping);
+    message<common_messages> msg(common_messages::client_ping);
     std::future<bool> send_result = simple_client.send(msg);
     bool sent = send_result.get();
     assert(sent);
     std::cout << "[client]: sent\n";
 
-    std::cout << "[client]: running updated loop\n";
-    while (simple_client.is_connected()) {
-        simple_client.update();
-    }
+    std::cout << "[client]: running loop\n";
+
+    simple_client.run(execution_policy::blocking);
 
     std::cout << "[client]: got out of the loop\n";
 

--- a/examples/simple_application/src/server.cpp
+++ b/examples/simple_application/src/server.cpp
@@ -3,9 +3,11 @@
 
 #include <iostream>
 
-class server : public wired::server_interface<common_messages> {
+using namespace wired;
+
+class server : public server_interface<common_messages> {
   public:
-    server() : wired::server_interface<common_messages>() {}
+    server() : server_interface<common_messages>() {}
     virtual ~server() {}
 
     void on_message(message_t& msg, connection_ptr conn) override {
@@ -27,18 +29,17 @@ class server : public wired::server_interface<common_messages> {
 };
 
 int main() {
-    WIRED_LOG_LEVEL(wired::log_level::LOG_DEBUG);
+    WIRED_LOG_LEVEL(log_level::LOG_DEBUG);
     server simple_server;
     std::cout << "[server]: starting\n";
     simple_server.start("60000");
 
     std::cout << "[server]: running\n";
-    while (true) {
-        simple_server.update();
-    }
+
+    simple_server.run(execution_policy::blocking);
 
     std::cout << "[server]: stopping\n";
-    simple_server.stop();
+    simple_server.shutdown();
 
     return 0;
 }

--- a/include/wired/connection.h
+++ b/include/wired/connection.h
@@ -23,13 +23,14 @@ class connection : public std::enable_shared_from_this<connection<T>> {
 
   public:
     connection(asio::io_context& io_context, asio::ip::tcp::socket&& socket,
-               ts_deque<message_t>& incoming_messages);
+               ts_deque<message_t>& incoming_messages,
+               std::condition_variable& cv);
     connection(const connection& other) = delete;
-    connection(connection&& other);
+    connection(connection&& other) noexcept;
     ~connection();
 
     connection& operator=(const connection&& other) = delete;
-    connection& operator=(connection&& other);
+    connection& operator=(connection&& other) noexcept;
 
     bool is_connected() const;
     std::future<bool> send(const message_t& msg, message_strategy strategy);
@@ -69,14 +70,18 @@ class connection : public std::enable_shared_from_this<connection<T>> {
     ts_deque<std::pair<message_t, std::promise<bool>>> outgoing_messages_;
     ts_deque<message_t>& incoming_messages_;
     message_t aux_message_;
+    std::condition_variable& cv_;
 };
 
 template <typename T>
 connection<T>::connection(asio::io_context& io_context,
                           asio::ip::tcp::socket&& socket,
-                          ts_deque<message_t>& incoming_messages)
+                          ts_deque<message_t>& incoming_messages,
+                          std::condition_variable& cv)
     : io_context_(io_context), socket_(std::move(socket)), outgoing_messages_(),
-      incoming_messages_(incoming_messages), aux_message_() {
+      incoming_messages_(incoming_messages), aux_message_(), cv_(cv) {
+    WIRED_LOG_MESSAGE(wired::LOG_DEBUG,
+                      "Connection object [{}] called constructor", (void*)this);
     if (!is_connected()) {
         return;
     }
@@ -84,12 +89,15 @@ connection<T>::connection(asio::io_context& io_context,
 }
 
 template <typename T>
-connection<T>::connection(connection&& other)
+connection<T>::connection(connection&& other) noexcept
     : io_context_(std::move(other.io_context_)),
       socket_(std::move(other.socket_)),
       outgoing_messages_(std::move(other.outgoing_messages_)),
       incoming_messages_(std::move(other.incoming_messages_)),
-      aux_message_(std::move(other.aux_message_)) {
+      aux_message_(std::move(other.aux_message_)), cv_(std::move(other.cv_)) {
+    WIRED_LOG_MESSAGE(log_level::LOG_DEBUG,
+                      "Connection object [{}] called move constructor",
+                      (void*)this);
     if (!is_connected()) {
         return;
     }
@@ -98,9 +106,8 @@ connection<T>::connection(connection&& other)
 
 template <typename T>
 connection<T>::~connection() {
-    if (is_connected()) {
-        disconnect();
-    }
+    WIRED_LOG_MESSAGE(wired::LOG_DEBUG,
+                      "Connection object [{}] called destructor", (void*)this);
 }
 
 template <typename T>
@@ -172,32 +179,53 @@ std::future<bool> connection<T>::disconnect() {
         promise.set_value(false);
         return future;
     }
+    WIRED_LOG_MESSAGE(wired::LOG_DEBUG,
+                      "Connection object [{}] called disconnect", (void*)this);
     asio::post(io_context_, [this, promise = std::move(promise)]() mutable {
         asio::error_code error;
         socket_.shutdown(asio::ip::tcp::socket::shutdown_both, error);
         if (error) {
-            WIRED_LOG_MESSAGE(wired::LOG_ERROR,
-                              "Socket error while shutting down send/write "
-                              "with error code: {} "
-                              "and error message: {}",
-                              error.value(), error.message());
-            promise.set_exception(std::make_exception_ptr(std::runtime_error(
-                "Socket shutdown error: " + std::to_string(error.value()) +
-                " - " + error.message())));
-            return;
+            if (is_disconnect_error(error)) {
+                WIRED_LOG_MESSAGE(
+                    wired::LOG_INFO,
+                    "{} Remote disconnected gracefully from shutdown "
+                    "with error code: {} "
+                    "and error message: {}",
+                    (void*)this, error.value(), error.message());
+            } else {
+                WIRED_LOG_MESSAGE(wired::LOG_ERROR,
+                                  "{} Socket error while shutting down "
+                                  "with error code: {} "
+                                  "and error message: {}",
+                                  (void*)this, error.value(), error.message());
+                promise.set_exception(std::make_exception_ptr(
+                    std::runtime_error("Socket shutdown error: " +
+                                       std::to_string(error.value()) + " - " +
+                                       error.message())));
+            }
         }
+
         error.clear();
         socket_.close(error);
         if (error) {
-            WIRED_LOG_MESSAGE(wired::LOG_ERROR,
-                              "Socket error while closing "
-                              "with error code: {} "
-                              "and error message: {}",
-                              error.value(), error.message());
-            promise.set_exception(std::make_exception_ptr(std::runtime_error(
-                "Socket close error: " + std::to_string(error.value()) + " - " +
-                error.message())));
-            return;
+            if (is_disconnect_error(error)) {
+                WIRED_LOG_MESSAGE(
+                    wired::LOG_INFO,
+                    "{} Remote disconnected gracefully from close "
+                    "with error code: {} "
+                    "and error message: {}",
+                    (void*)this, error.value(), error.message());
+            } else {
+                WIRED_LOG_MESSAGE(wired::LOG_ERROR,
+                                  "{} Socket error while closing "
+                                  "with error code: {} "
+                                  "and error message: {}",
+                                  (void*)this, error.value(), error.message());
+                promise.set_exception(
+                    std::make_exception_ptr(std::runtime_error(
+                        "Socket close error: " + std::to_string(error.value()) +
+                        " - " + error.message())));
+            }
         }
         outgoing_messages_.clear();
         incoming_messages_.clear();
@@ -239,17 +267,18 @@ void connection<T>::read_header_handler(const asio::error_code& error,
                                         std::size_t bytes_transferred) {
     if (error) {
         if (is_disconnect_error(error)) {
-            WIRED_LOG_MESSAGE(wired::LOG_INFO,
-                              "Remote disconnected gracefully from read_header "
-                              "with error code: "
-                              "{} and error message: {}",
-                              error.value(), error.message());
+            WIRED_LOG_MESSAGE(
+                wired::LOG_INFO,
+                "{} Remote disconnected gracefully from read_header "
+                "with error code: "
+                "{} and error message: {}",
+                (void*)this, error.value(), error.message());
         } else {
             WIRED_LOG_MESSAGE(wired::LOG_ERROR,
-                              "Error while reading header "
+                              "{} Error while reading header "
                               "with error code: {} "
                               "and error message: {}",
-                              error.value(), error.message());
+                              (void*)this, error.value(), error.message());
         }
         disconnect();
         return;
@@ -280,17 +309,18 @@ void connection<T>::read_body_handler(const asio::error_code& error,
                                       std::size_t bytes_transferred) {
     if (error) {
         if (is_disconnect_error(error)) {
-            WIRED_LOG_MESSAGE(wired::LOG_INFO,
-                              "Remote disconnected gracefully from read_body "
-                              "with error code: "
-                              "{} and error message: {}",
-                              error.value(), error.message());
+            WIRED_LOG_MESSAGE(
+                wired::LOG_INFO,
+                "{} Remote disconnected gracefully from read_body "
+                "with error code: "
+                "{} and error message: {}",
+                (void*)this, error.value(), error.message());
         } else {
             WIRED_LOG_MESSAGE(wired::LOG_ERROR,
-                              "Error while reading body "
+                              "{} Error while reading body "
                               "with error code: {} "
                               "and error message: {}",
-                              error.value(), error.message());
+                              (void*)this, error.value(), error.message());
         }
         disconnect();
         return;
@@ -322,16 +352,16 @@ void connection<T>::write_header_handler(const asio::error_code& error,
         if (is_disconnect_error(error)) {
             WIRED_LOG_MESSAGE(
                 wired::LOG_INFO,
-                "Remote disconnected gracefully from write_header "
+                "{} Remote disconnected gracefully from write_header "
                 "with error code: "
                 "{} and error message: {}",
-                error.value(), error.message());
+                (void*)this, error.value(), error.message());
         } else {
             WIRED_LOG_MESSAGE(wired::LOG_ERROR,
-                              "Error while writing header "
+                              "{} Error while writing header "
                               "with error code: {} "
                               "and error message: {}",
-                              error.value(), error.message());
+                              (void*)this, error.value(), error.message());
         }
         disconnect();
         promise.set_exception(std::make_exception_ptr(std::runtime_error(
@@ -374,17 +404,18 @@ void connection<T>::write_body_handler(const asio::error_code& error,
     auto& promise = pair.second;
     if (error) {
         if (is_disconnect_error(error)) {
-            WIRED_LOG_MESSAGE(wired::LOG_INFO,
-                              "Remote disconnected gracefully from write_body "
-                              "with error code: {} "
-                              "and error message: {}",
-                              error.value(), error.message());
+            WIRED_LOG_MESSAGE(
+                wired::LOG_INFO,
+                "{} Remote disconnected gracefully from write_body "
+                "with error code: {} "
+                "and error message: {}",
+                (void*)this, error.value(), error.message());
         } else {
             WIRED_LOG_MESSAGE(wired::LOG_ERROR,
-                              "Error while writing body "
+                              "{} Error while writing body "
                               "with error code: {} "
                               "and error message: {}",
-                              error.value(), error.message());
+                              (void*)this, error.value(), error.message());
         }
         disconnect();
         promise.set_exception(std::make_exception_ptr(std::runtime_error(
@@ -413,6 +444,7 @@ void connection<T>::append_finished_message() {
     aux_message_.from() = this->shared_from_this();
     incoming_messages_.emplace_back(std::move(aux_message_));
     aux_message_.reset();
+    cv_.notify_all();
     read_header();
 }
 

--- a/include/wired/connection.h
+++ b/include/wired/connection.h
@@ -94,7 +94,7 @@ connection<T>::connection(connection&& other) noexcept
       socket_(std::move(other.socket_)),
       outgoing_messages_(std::move(other.outgoing_messages_)),
       incoming_messages_(std::move(other.incoming_messages_)),
-      aux_message_(std::move(other.aux_message_)), cv_(std::move(other.cv_)) {
+      aux_message_(std::move(other.aux_message_)), cv_(other.cv_) {
     WIRED_LOG_MESSAGE(log_level::LOG_DEBUG,
                       "Connection object [{}] called move constructor",
                       (void*)this);

--- a/include/wired/message.h
+++ b/include/wired/message.h
@@ -103,6 +103,7 @@ message_body<T>& message_body<T>::operator=(message_body&& other) noexcept {
 template <typename T>
 class message {
   public:
+    using value_type = T;
     using connection_t = connection<T>;
     using connection_ptr = std::shared_ptr<connection_t>;
     using message_header_t = message_header<T>;

--- a/include/wired/server.h
+++ b/include/wired/server.h
@@ -112,7 +112,11 @@ void server_interface<T>::shutdown() {
         result.wait();
     }
 
+    stop_messaging_loop_ = true;
     cv_.notify_all();
+    if (messages_thread_.joinable()) {
+        messages_thread_.join();
+    }
 
     connections_.clear();
     messages_.clear();

--- a/include/wired/server.h
+++ b/include/wired/server.h
@@ -244,7 +244,7 @@ void server_interface<T>::wait_for_client_chain() {
             } else {
                 WIRED_LOG_MESSAGE(
                     log_level::LOG_DEBUG,
-                    "wait_for_client_chain didn't succed to accept a "
+                    "wait_for_client_chain didn't succeed to accept a "
                     "connection with error code: {} and error message: {}",
                     ec.value(), ec.message());
             }

--- a/include/wired/server.h
+++ b/include/wired/server.h
@@ -36,35 +36,55 @@ class server_interface {
     send(connection_ptr conn, const message_t& msg,
          message_strategy strategy = message_strategy::normal);
 
-    std::future<bool>
+    std::vector<std::future<bool>>
     send_all(connection_ptr ignore, const message_t& msg,
              message_strategy strategy = message_strategy::normal);
 
-    bool update();
+    std::future<bool> kick(connection_ptr conn);
+
+    void run(execution_policy policy = execution_policy::blocking);
 
   private:
-    void run();
+    void messaging_loop();
+    void contribute_to_context_pool();
+    void on_message_notify_callback();
     void wait_for_client_chain();
 
   private:
     asio::io_context context_;
     asio::executor_work_guard<asio::io_context::executor_type> idle_work_;
-    std::thread thread_;
+    std::thread asio_thread_;
     asio::ip::tcp::acceptor acceptor_;
     ts_deque<connection_ptr> connections_;
     ts_deque<message_t> messages_;
+    std::thread messages_thread_;
+    std::condition_variable cv_;
+    std::mutex mutex_;
+    std::atomic<bool> stop_messaging_loop_{false};
 }; // class server_interface
 
 template <typename T>
 server_interface<T>::server_interface()
-    : context_(), idle_work_(asio::make_work_guard(context_)), thread_(),
-      acceptor_(context_), connections_(), messages_() {
-    thread_ = std::thread(&server_interface<T>::run, this);
+    : context_(), idle_work_(asio::make_work_guard(context_)), asio_thread_(),
+      acceptor_(context_), connections_(), messages_(), messages_thread_(),
+      cv_(), mutex_() {
+    asio_thread_ =
+        std::thread(&server_interface<T>::contribute_to_context_pool, this);
 }
 
 template <typename T>
 server_interface<T>::~server_interface() {
-    stop();
+    WIRED_LOG_MESSAGE(log_level::LOG_DEBUG,
+                      "server_interface object [{}] destructor called",
+                      (void*)this);
+    if (asio_thread_.joinable()) {
+        asio_thread_.join();
+    }
+    stop_messaging_loop_ = true;
+    cv_.notify_all();
+    if (messages_thread_.joinable()) {
+        messages_thread_.join();
+    }
 }
 
 template <typename T>
@@ -79,17 +99,27 @@ void server_interface<T>::start(const std::string& port) {
 
 template <typename T>
 void server_interface<T>::shutdown() {
-    connections_.for_each([](connection_ptr conn) {
+    WIRED_LOG_MESSAGE(log_level::LOG_DEBUG,
+                      "server_interface shutdown started");
+
+    std::vector<std::future<bool>> results;
+    connections_.for_each([&results](connection_ptr conn) {
         if (conn->is_connected()) {
-            conn->disconnect();
+            results.push_back(conn->disconnect());
         }
     });
+    for (auto& result : results) {
+        result.wait();
+    }
+
+    cv_.notify_all();
+
     connections_.clear();
     messages_.clear();
     acceptor_.close();
 
     context_.stop();
-    thread_.join();
+    asio_thread_.join();
     idle_work_.reset();
     WIRED_LOG_MESSAGE(log_level::LOG_DEBUG,
                       "server_interface shutdown completed");
@@ -101,39 +131,99 @@ bool server_interface<T>::is_listening() {
 }
 
 template <typename T>
-bool server_interface<T>::send(connection_ptr conn, const message_t& msg,
-                               message_strategy strategy) {
+std::future<bool> server_interface<T>::send(connection_ptr conn,
+                                            const message_t& msg,
+                                            message_strategy strategy) {
     if (conn && conn->is_connected()) {
-        conn->send(msg, strategy);
-        return true;
+        return conn->send(msg, strategy);
     }
-    return false;
+    std::promise<bool> promise;
+    promise.set_value(false);
+    return promise.get_future();
 }
 
 template <typename T>
-bool server_interface<T>::send_all(connection_ptr ignore, const message_t& msg,
-                                   message_strategy strategy) {
-    connections_.for_each([&msg, &ignore, strategy](connection_ptr conn) {
-        if (conn != ignore && conn->is_connected()) {
-            conn->send(msg, strategy);
+std::vector<std::future<bool>>
+server_interface<T>::send_all(connection_ptr ignore, const message_t& msg,
+                              message_strategy strategy) {
+    std::vector<std::future<bool>> results;
+    connections_.for_each(
+        [&results, &msg, &ignore, strategy](connection_ptr conn) {
+            if (conn != ignore && conn->is_connected()) {
+                results.push_back(conn->send(msg, strategy));
+            }
+        });
+    return results;
+}
+
+template <typename T>
+std::future<bool> server_interface<T>::kick(connection_ptr conn) {
+    if (conn && conn->is_connected()) {
+        auto ret = conn->disconnect();
+        connections_.erase_remove(conn);
+        return ret;
+    }
+    // FIXME: After disconnecting, the connection is not removed from the list
+    std::promise<bool> promise;
+    promise.set_value(false);
+    return promise.get_future();
+}
+
+template <typename T>
+void server_interface<T>::run(execution_policy policy) {
+    if (policy == execution_policy::blocking) {
+        WIRED_LOG_MESSAGE(log_level::LOG_DEBUG,
+                          "Server message handler is running in blocking mode");
+        messaging_loop();
+    } else if (policy == execution_policy::non_blocking) {
+        if (messages_thread_.joinable()) {
+            WIRED_LOG_MESSAGE(log_level::LOG_ERROR,
+                              "Messaging thread is already running");
+            throw std::runtime_error("Messaging thread is already running");
         }
-    });
-    return true;
-}
-
-template <typename T>
-bool server_interface<T>::update() {
-    if (messages_.empty()) {
-        return false;
+        WIRED_LOG_MESSAGE(log_level::LOG_DEBUG,
+                          "Server message handler is running in non-blocking "
+                          "mode");
+        messages_thread_ =
+            std::thread(&server_interface<T>::messaging_loop, this);
     }
-    message_t msg = messages_.front();
-    messages_.pop_front();
-    on_message(msg, msg.from());
-    return true;
 }
 
 template <typename T>
-void server_interface<T>::run() {
+void server_interface<T>::messaging_loop() {
+    while (is_listening()) {
+        std::unique_lock<std::mutex> lock(mutex_);
+        WIRED_LOG_MESSAGE(log_level::LOG_DEBUG,
+                          "Waiting for messages in the queue");
+        cv_.wait(lock, [this] {
+            return (!messages_.empty() || stop_messaging_loop_);
+        });
+        if (stop_messaging_loop_) {
+            WIRED_LOG_MESSAGE(log_level::LOG_DEBUG,
+                              "Stop messaging loop, exiting");
+            return;
+        }
+        WIRED_LOG_MESSAGE(log_level::LOG_DEBUG,
+                          "Messages in the queue, processing them");
+
+        while (!messages_.empty()) {
+            if (stop_messaging_loop_) {
+                WIRED_LOG_MESSAGE(log_level::LOG_DEBUG,
+                                  "Stop messaging loop, exiting");
+                return;
+            }
+            message_t msg = messages_.front();
+            messages_.pop_front();
+            WIRED_LOG_MESSAGE(log_level::LOG_DEBUG,
+                              "Processing message with id {}",
+                              static_cast<uint32_t>(msg.head().id()));
+            on_message(msg, msg.from());
+        }
+    }
+}
+
+template <typename T>
+void server_interface<T>::contribute_to_context_pool() {
     context_.run();
 }
 
@@ -142,19 +232,21 @@ void server_interface<T>::wait_for_client_chain() {
     acceptor_.async_accept(
         [this](std::error_code ec, asio::ip::tcp::socket socket) {
             if (!ec) {
-                WIRED_LOG_MESSAGE(
-                    log_level::LOG_DEBUG,
-                    "wait_for_client_chain successfully accepted a connection");
                 connection_ptr conn = std::make_shared<connection_t>(
-                    context_, std::move(socket), messages_);
+                    context_, std::move(socket), messages_, cv_);
+                WIRED_LOG_MESSAGE(log_level::LOG_DEBUG,
+                                  "wait_for_client_chain successfully accepted "
+                                  "a connection, obj addr {}",
+                                  (void*)conn.get());
                 if (conn->is_connected()) {
                     connections_.push_back(conn);
                 }
             } else {
-
-                WIRED_LOG_MESSAGE(log_level::LOG_DEBUG,
-                                  "wait_for_client_chain didn't succed "
-                                  "accepted a connection");
+                WIRED_LOG_MESSAGE(
+                    log_level::LOG_DEBUG,
+                    "wait_for_client_chain didn't succed to accept a "
+                    "connection with error code: {} and error message: {}",
+                    ec.value(), ec.message());
             }
             wait_for_client_chain();
         });

--- a/include/wired/tools/log.h
+++ b/include/wired/tools/log.h
@@ -6,6 +6,9 @@
 #include <format>
 #include <iostream>
 #include <mutex>
+#include <sstream>
+#include <string>
+#include <thread>
 
 namespace wired {
 
@@ -43,10 +46,13 @@ template <typename... Args>
 void log_message_function(log_level lvl, const char* file, int line,
                           const char* msg, Args&&... args) {
     std::lock_guard<std::mutex> lock(log_mutex);
+    std::ostringstream calling_thread;
+    calling_thread << std::this_thread::get_id();
     std::string short_filename = shorten_filename(file);
     if (current_lvl <= lvl && current_lvl != LOG_DISABLE) {
-        std::cout << std::format("[{}:{}][{}]: ", short_filename, line,
-                                 log_level_names[static_cast<uint8_t>(lvl)]);
+        std::cout << std::format("[{}:{}][{}][TID: {}]: ", short_filename, line,
+                                 log_level_names[static_cast<uint8_t>(lvl)],
+                                 calling_thread.str());
         std::cout << std::vformat(msg, std::make_format_args(args...));
         std::cout << std::endl;
     }

--- a/include/wired/ts_deque.h
+++ b/include/wired/ts_deque.h
@@ -18,6 +18,8 @@ namespace wired {
 template <typename T>
 class ts_deque {
   public:
+    using value_type = typename std::deque<T>::value_type;
+
     using iterator = typename std::deque<T>::iterator;
     using reference = typename std::deque<T>::reference;
     using const_reference = typename std::deque<T>::const_reference;
@@ -75,6 +77,8 @@ class ts_deque {
 
     template <typename... Args>
     void add_message(message_strategy strategy, Args&&... args);
+
+    void erase_remove(value_type value);
 
   private:
     std::deque<T> deque_;
@@ -287,6 +291,15 @@ void ts_deque<T>::add_message(message_strategy strategy, Args&&... args) {
         deque_.emplace_front(std::forward<Args>(args)...);
     } else {
         throw std::invalid_argument("Invalid/Unsupported message strategy");
+    }
+}
+
+template <typename T>
+void ts_deque<T>::erase_remove(value_type value) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    auto it = std::remove(deque_.begin(), deque_.end(), value);
+    if (it != deque_.end()) {
+        deque_.erase(it, deque_.end());
     }
 }
 

--- a/include/wired/types.h
+++ b/include/wired/types.h
@@ -10,6 +10,11 @@ enum class message_strategy : uint8_t {
     immediate = 1 << 1
 }; // enum class message_strategy
 
+enum class execution_policy {
+    blocking,
+    non_blocking
+}; // enum class execution_policy
+
 struct selection_tag_0 {};
 struct selection_tag_1 : selection_tag_0 {};
 struct selection_tag_2 : selection_tag_1 {};

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -14,7 +14,8 @@ set(UNIT_TEST_SOURCES
     "src/main.cpp"
     "src/message_tests.cpp"
     "src/connection_tests.cpp"
-    "src/sanity.cpp")
+    "src/sanity.cpp"
+    "src/client_server_tests.cpp")
 
 add_executable(unit ${UNIT_TEST_SOURCES})
 

--- a/tests/unit/include/test_client.h
+++ b/tests/unit/include/test_client.h
@@ -1,0 +1,30 @@
+#include "wired.h"
+#include "test_enums.h"
+#include "test_types.h"
+#include <thread>
+
+class client_t : public wired::client_interface<message_type> {
+  public:
+    using message_t = wired::message<message_type>;
+    using connection_t = wired::connection<message_type>;
+    using connection_ptr = std::shared_ptr<connection_t>;
+    using ts_deque = wired::ts_deque<message_t>;
+
+  public:
+    client_t() : wired::client_interface<message_type>(), frequency({0}) {}
+    ~client_t() override {}
+
+    void on_message(message_t& msg, connection_ptr conn) override {
+        std::cout << "Client received message with id: "
+                  << static_cast<uint32_t>(msg.id()) << std::endl;
+        ++frequency[static_cast<uint32_t>(msg.id())];
+    }
+
+    uint32_t get_frequency(message_type type) const {
+        return frequency[static_cast<uint32_t>(type)];
+    }
+
+    std::array<uint32_t,
+               static_cast<uint32_t>(message_type::message_type_count)>
+        frequency;
+};

--- a/tests/unit/include/test_enums.h
+++ b/tests/unit/include/test_enums.h
@@ -5,5 +5,9 @@
 enum class message_type : uint8_t {
     single,
     vector,
-    wired_serialize
+    wired_serialize,
+    client_message,
+    server_message,
+
+    message_type_count // This should be the last enum value
 };

--- a/tests/unit/include/test_server.h
+++ b/tests/unit/include/test_server.h
@@ -1,0 +1,31 @@
+#include "wired.h"
+#include "test_enums.h"
+#include "test_types.h"
+#include <thread>
+#include <array>
+
+class server_t : public wired::server_interface<message_type> {
+  public:
+    using message_t = wired::message<message_type>;
+    using connection_t = wired::connection<message_type>;
+    using connection_ptr = std::shared_ptr<connection_t>;
+    using ts_deque = wired::ts_deque<message_t>;
+
+  public:
+    server_t() : wired::server_interface<message_type>(), frequency({0}) {}
+    ~server_t() override {}
+
+    void on_message(message_t& msg, connection_ptr conn) override {
+        std::cout << "Server received message with id: "
+                  << static_cast<uint32_t>(msg.id()) << std::endl;
+        ++frequency[static_cast<uint32_t>(msg.id())];
+    }
+
+    uint32_t get_frequency(message_type type) const {
+        return frequency[static_cast<uint32_t>(type)];
+    }
+
+    std::array<uint32_t,
+               static_cast<uint32_t>(message_type::message_type_count)>
+        frequency;
+};

--- a/tests/unit/src/client_server_tests.cpp
+++ b/tests/unit/src/client_server_tests.cpp
@@ -1,0 +1,92 @@
+#include "wired.h"
+#include "test_client.h"
+#include "test_server.h"
+
+#include <gtest/gtest.h>
+#include <thread>
+
+class client_server_tests_fixture : public ::testing::Test {
+  public:
+    using message_t = wired::message<message_type>;
+    using connection_t = wired::connection<message_type>;
+    using connection_ptr = std::shared_ptr<connection_t>;
+    using ts_deque = wired::ts_deque<message_t>;
+
+  public:
+    void SetUp() override {
+        server_.start("60000");
+        server_.run(wired::execution_policy::non_blocking);
+        for (auto& client : clients_) {
+            auto future = client.connect("localhost", "60000");
+            ASSERT_TRUE(future.get());
+            ASSERT_TRUE(client.is_connected());
+            client.run(wired::execution_policy::non_blocking);
+        }
+        std::cout << " ===== Server and clients are set up ===== " << std::endl;
+    }
+
+    void TearDown() override {
+        std::cout << " ===== Server and clients are tearing down ===== "
+                  << std::endl;
+        for (auto& client : clients_) {
+            if (client.is_connected()) {
+                auto future = client.disconnect();
+                ASSERT_TRUE(future.get());
+                ASSERT_FALSE(client.is_connected());
+            }
+        }
+        if (server_.is_listening()) {
+            server_.shutdown();
+        }
+    }
+
+  protected:
+    server_t server_;
+    std::array<client_t, 3> clients_;
+};
+
+TEST_F(client_server_tests_fixture, assert_connections) {
+    ASSERT_TRUE(server_.is_listening());
+    for (auto& client : clients_) {
+        ASSERT_TRUE(client.is_connected());
+    }
+}
+
+TEST_F(client_server_tests_fixture, server_disconnect) {
+    server_.shutdown();
+    ASSERT_FALSE(server_.is_listening());
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    for (auto& client : clients_) {
+        ASSERT_FALSE(client.is_connected());
+    }
+}
+
+TEST_F(client_server_tests_fixture, client_disconnect) {
+    for (auto& client : clients_) {
+        auto future = client.disconnect();
+        ASSERT_TRUE(future.get());
+        ASSERT_FALSE(client.is_connected());
+    }
+}
+
+TEST_F(client_server_tests_fixture, server_send) {
+    message_t msg(message_type::server_message);
+    auto results = server_.send_all(nullptr, msg);
+    for (auto& result : results) {
+        ASSERT_TRUE(result.get());
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    for (auto& client : clients_) {
+        ASSERT_EQ(client.get_frequency(message_type::server_message), 1);
+    }
+}
+
+TEST_F(client_server_tests_fixture, client_send) {
+    message_t msg(message_type::client_message);
+    for (auto& client : clients_) {
+        auto results = client.send(msg);
+        ASSERT_TRUE(results.get());
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    ASSERT_EQ(server_.get_frequency(message_type::client_message), 3);
+}

--- a/tests/unit/src/connection_tests.cpp
+++ b/tests/unit/src/connection_tests.cpp
@@ -5,6 +5,7 @@
 
 #include <gtest/gtest.h>
 #include <thread>
+#include <mutex>
 
 class connection_tests_fixture : public ::testing::Test {
   public:
@@ -46,7 +47,7 @@ class connection_tests_fixture : public ::testing::Test {
                                   "Server accepted connection");
                 server_conn = std::make_shared<connection_t>(
                     io_context, std::move(server_socket),
-                    server_incoming_messages);
+                    server_incoming_messages, placeholder_cv);
             } else {
                 WIRED_LOG_MESSAGE(wired::LOG_ERROR,
                                   "Server failed to accept connection");
@@ -70,7 +71,7 @@ class connection_tests_fixture : public ::testing::Test {
                                       "Client connected to server");
                     client_conn = std::make_shared<connection_t>(
                         io_context, std::move(client_socket),
-                        client_incoming_messages);
+                        client_incoming_messages, placeholder_cv);
                 } else {
                     WIRED_LOG_MESSAGE(wired::LOG_ERROR,
                                       "Client failed to connect to server");
@@ -90,6 +91,7 @@ class connection_tests_fixture : public ::testing::Test {
     void TearDown() override {}
 
   protected:
+    std::condition_variable placeholder_cv;
     asio::io_context io_context;
     asio::ip::tcp::socket server_socket;
     asio::ip::tcp::socket client_socket;


### PR DESCRIPTION
This PR  adds massive improvements to the server interface, adhering to the std::future returning standard and also introduces the redesign of the message handling mechanism which is decoupled from the asio queue for efficency reasons, adding a non-busy wait loop that handles the messages. It adds an execution policy, which can be blocking or non-blocking, default is blocking, so the user can choose. There are also tests added for client server use cases.